### PR TITLE
Account for temporary mix.js chunk

### DIFF
--- a/src/SriPlugin.js
+++ b/src/SriPlugin.js
@@ -1,4 +1,5 @@
 require('laravel-mix/src/helpers')
+const collect = require('collect.js');
 const path = require('path');
 
 class SriPlugin {
@@ -10,6 +11,11 @@ class SriPlugin {
     const process = stats => {
       let assets = Object.assign({}, stats.toJson().assetsByChunkName)
       let hashes = {}
+
+      // If there's a temporary mix.js chunk, we can safely remove it.
+      if (assets.mix) {
+        assets.mix = collect(assets.mix).except('mix.js').all();
+      }
 
       flatten(assets).forEach(asset => {
         if (asset[0] !== '/') {


### PR DESCRIPTION
Mix creates a `mix.js` temporary chunk if you're using Mix without processing any JavaScript.  Its [`MockEntryPlugin`](https://github.com/JeffreyWay/laravel-mix/blob/v6.0.10/src/webpackPlugins/MockEntryPlugin.js) is responsible for cleaning up this temporary asset at the end of the process, but that means that it is still in the assets list when plugins are being processed.  So, the `SriPlugin` needs to be aware of this temporary chunk and ignore it to prevent errors on projects without JavaScript.

The patch here uses the same logic as Mix' [`Manifest.flattenAssets()`](https://github.com/JeffreyWay/laravel-mix/blob/v6.0.10/src/Manifest.js#L97) method to filter out the chunk.