### PR TITLE
Downgrade required Node.js version to LTS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "typescript": "^4.2.4"
             },
             "engines": {
-                "node": ">=15.0.0"
+                "node": ">=14.0.0"
             },
             "peerDependencies": {
                 "laravel-mix": "^6.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "laravel-mix": "^6.0"
     },
     "engines": {
-        "node": ">=15.0.0"
+        "node": ">=14.0.0"
     },
     "devDependencies": {
         "laravel-mix": "^6.0",


### PR DESCRIPTION
As mentioned in #31, this makes it so the LTS version of Node.js is also supported.