### PR TITLE
Add algorithm type to the hash string

### DIFF
--- a/src/SriPlugin.ts
+++ b/src/SriPlugin.ts
@@ -32,7 +32,7 @@ export default class SriPlugin implements webpack.WebpackPluginInstance {
 
           filePath = filePath.replace(/\?id=\w{20}/, '')
 
-          hashes[filePath] = crypto
+          hashes[filePath] = this.algorithm + '-' + crypto
             .createHash(this.algorithm)
             .update(
               fs.readFileSync(


### PR DESCRIPTION
## Summary
Fix the Invalid attribute type error when use used with laravel-sri. 

## Details
The SRI attribute should include the algorithm type separated by a '-'. Since the purpose of the package is to generate SRI the output hash should include this information. Without the algorithm type the browser will throw the Invalid attribute type error. This PR fixes the error.

P.S: This is my first PR so if I made any newbie errors, please do point them out.