### PR TITLE
feat: make output configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ $ npm install laravel-mix-sri
 You can pass an object to the function. Available keys are:
 - `enabled`: boolean, default: `mix.Inproduction()`
 - `algorithm`: string, default: `'sha256'`
+- `output`: string, default: `'mix-sri.json'`
 
 ## Usage
 
@@ -29,9 +30,9 @@ mix.sass('src/app.sass', 'dist')
    .generateIntegrityHash()
 ```
 
-At every build it'll generate (or update the content of) a `mix-sri.json` file. The file is located within the `public` directory with the `mix-manifest.json`.
+At every build it'll generate (or update the content of) the `output` file. The file is located within the `public` directory with the `mix-manifest.json`.
 
-You can use [laravel-sri](https://github.com/Elhebert/laravel-sri) package to parse the `mix-sri.json` file and generate according attributes for your assets.
+You can use [laravel-sri](https://github.com/Elhebert/laravel-sri) package to parse the `output` file and generate according attributes for your assets.
 
 ## Contributing
 

--- a/src/SriPlugin.ts
+++ b/src/SriPlugin.ts
@@ -6,8 +6,7 @@ import path from 'path'
 import { cwd } from 'process'
 
 export default class SriPlugin implements webpack.WebpackPluginInstance {
-  constructor(private algorithm: 'sha256' | 'sha384' | 'sha512') {
-    this.algorithm = algorithm
+  constructor(private algorithm: 'sha256' | 'sha384' | 'sha512', private output = 'mix-sri.json') {
   }
 
   apply(compiler: webpack.Compiler): void {
@@ -46,7 +45,7 @@ export default class SriPlugin implements webpack.WebpackPluginInstance {
 
       fs.writeFileSync(
         // @ts-ignore TS2304
-        path.join(cwd(), Config.publicPath, 'mix-sri.json'),
+        path.join(cwd(), Config.publicPath, this.output),
         JSON.stringify(hashes, null, 4)
       )
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { ClassComponent } from 'laravel-mix/types/component'
 
 export type Options = {
   algorithm?: 'sha256' | 'sha384' | 'sha512'
+  output?: string
   enabled?: boolean
 }
 
@@ -18,6 +19,7 @@ class IntegrityHash implements ClassComponent {
   register(options: Options = {}): void {
     this.config = {
       algorithm: 'sha256',
+      output: options.output,
       enabled: options.enabled || mix.inProduction(),
     }
 
@@ -28,7 +30,7 @@ class IntegrityHash implements ClassComponent {
 
   webpackPlugins(): webpack.WebpackPluginInstance[] {
     if (this.config.enabled) {
-      return [new SriPlugin(this.config.algorithm)]
+      return [new SriPlugin(this.config.algorithm, this.config.output)]
     }
   }
 }


### PR DESCRIPTION
This feature allows you to specify the path for the generated file.

```js
mix.generateIntegrityHash({output: 'mix-sri-manifest.json'})
```